### PR TITLE
Add issues template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+#### Your system information
+
+* Steam client version:
+* SteamOS version: 
+* Opted into Steam client beta?: [Yes/No] 
+* Opted into SteamOS beta?: [Yes/No] 
+* Have you checked for updates in Settings > System?: [Yes/No]
+
+#### Please describe your issue in as much detail as possible:
+
+
+#### Steps for reproducing this issue:
+

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -7,7 +7,10 @@
 * Have you checked for updates in Settings > System?: [Yes/No]
 
 #### Please describe your issue in as much detail as possible:
-
+Describe what you _expected_ should happen and what _did_ happen.
 
 #### Steps for reproducing this issue:
 
+1. 
+2. 
+3. 


### PR DESCRIPTION
See: 

* https://github.com/isaacs/github/issues/99#issuecomment-185412731
* https://github.com/blog/2111-issue-and-pull-request-templates

Github now allows pre-filled text in issues tickets. The text I have placed may not be _exactly_ what you want. I also suggest adding this markdown to the end:

---------------------

Note:
Please place logs either in a code block (press `M` in your browser for a GFM cheat sheet) or a [gist](https://gist.github.com) if they are lengthy. Information on log locations what what do with them, can be found on [wiki](https://github.com/ValveSoftware/SteamOS/wiki/Reviewing-log-information). _This block of text can then  be removed._