### PR TITLE
Fix formatting of issue tracker links in contributing.md

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -4,9 +4,9 @@ Reporting Issues
 If you encounter an issue while using SteamOS, first search the [issue list](https://github.com/ValveSoftware/SteamOS/issues) to see if it has already been reported. Include closed issues in your search.  Some issues may have already been reported to other trackers, so it may be worth checking the following:
 
 - [Steam for Linux](https://github.com/ValveSoftware/steam-for-linux/issues) for Steam Client issues
-- [Dota 2] (https://github.com/ValveSoftware/Dota-2/issues) for issues regarding Dota 2.
-- [HalfLife] (https://github.com/ValveSoftware/halflife/issues) for issues regarding Half-Life 1 engine (GoldSrc) games.
-- [Source-1 Games] (https://github.com/ValveSoftware/Source-1-Games/issues) for issues regarding Source games (HL2, TF2, CS:S, etc)
+- [Dota 2](https://github.com/ValveSoftware/Dota-2/issues) for issues regarding Dota 2.
+- [HalfLife](https://github.com/ValveSoftware/halflife/issues) for issues regarding Half-Life 1 engine (GoldSrc) games.
+- [Source-1 Games](https://github.com/ValveSoftware/Source-1-Games/issues) for issues regarding Source games (HL2, TF2, CS:S, etc)
 
 If it has not been reported, create a new issue with at least the following information:
 


### PR DESCRIPTION
These links should be formatted the same way as the `Steam for Linux `link