### PR TITLE
readme: replace FAQ link with more helpful links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,15 @@ SteamOS community tracker
 
 This issue tracker is meant for community support and requests for improvements.
 
-SteamOS FAQ
+SteamOS Installation and Repair
 -----------
 
-https://help.steampowered.com/en/faqs/view/79DC-B3D4-D352-A3CC
+https://help.steampowered.com/en/faqs/view/65B4-2AA3-5F37-4227
+
+SteamOS Recovery and Troubleshooting
+-----------
+
+https://help.steampowered.com/en/faqs/view/1B71-EDF2-EB6D-2BB3
 
 Reporting Issues
 ----------------


### PR DESCRIPTION
The FAQ page is still SteamOS 2.0-centric, so let's replace it with a link to the modern installation instructions page as well as the modern recovery and troubleshooting instructions.

should be the last one for now :frog: